### PR TITLE
Simplify Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.7.4"
-gem "github-pages", "~> 192"
-gem "rake", "~> 12.3.1"
-gem "slugify", "~> 1.0"
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
I was having an issue (similar to https://github.com/18F/jekyll_pages_api_search/issues/37) with `bundle exec jekyll serve` that I traced to the pinned jekyll version. Per https://github.com/github/pages-gem, we should just need the `github-pages` gem as specified here. @mgilbert1