### PR TITLE
Add back rake and slugify to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gem 'github-pages', group: :jekyll_plugins
+gem 'rake'
+gem 'slugify'


### PR DESCRIPTION
`bundle exec jekyll serve` worked without `rake` and `slugify` in the Gemfile, but the [GitHub Action broke](https://github.com/UBICenter/ubicenter.org/actions/runs/833412757) after merging #203, so trying to add it back. `jekyll` shouldn't be necessary since `github-pages` has `jekyll-octicons` as a dep, which has `jekyll` as a dep.