### PR TITLE
Link only part of the initial heading to get LaTeX to render in BIB post

### DIFF
--- a/_posts/2021-07-21-introducing-basic-income-builder.md
+++ b/_posts/2021-07-21-introducing-basic-income-builder.md
@@ -17,7 +17,7 @@ usemathjax: true
 <script src="https://requirejs.org/docs/release/2.3.5/minified/require.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 
-# [Try Basic Income Builder at bib.ubicenter.org](http://bib.ubicenter.org)
+# Try Basic Income Builder at [bib.ubicenter.org](http://bib.ubicenter.org)
 
 Using Python and Plotly Dash’s dashboarding tools, we've created Basic Income Builder: an interactive calculator that uses U.S. Census microdata to simulate distributional effects of a customizable UBI policy program. Users can experiment with a wide variety of inputs, from the size of the and type of taxation to reforms of the existing safety net programs. The calculator then produces interactive data visualizations that allow the user to explore the proposal's effect on the poverty rate for selected demographics, the poverty gap, and an estimate of what share of individuals come out ahead. Read on for more information, or try it yourself at [bib.ubicenter.org](http://bib.ubicenter.org).
 


### PR DESCRIPTION
There must be some interaction between the mathjax header and the link in the initial heading. Fixes #251 