### PR TITLE
Load mathjax over https

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -84,7 +84,7 @@
         TeX: { equationNumbers: { autoNumber: "AMS" } }
         });
         </script>
-        <script type="text/javascript" async src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        <script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     {% endif %}
 
     <!-- for plotly support -->


### PR DESCRIPTION
latex was loading locally but not on the live site:
>Mixed Content: The page at 'https://www.ubicenter.org/introducing-basic-income-builder' was loaded over HTTPS, but requested an insecure script 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'. This request has been blocked; the content must be served over HTTPS.