### PR TITLE
Remove plotly js and code blocks from post_from_notebook.py

### DIFF
--- a/post_from_notebook.py
+++ b/post_from_notebook.py
@@ -15,28 +15,6 @@ SCRIPT_TEMPLATE = """
 <div id = "graph_{id}"></div>
 """
 
-CODE_BLOCK = """
-<button onclick="show_code_{id}()">Click to show code</button>
-<div id="code_block_{id}" style="display: none;">
-  <pre>
-    <code>
-{code}
-    </code>
-  </pre>
-</div>
-
-<script>
-function show_code_{id}() {
-  var x = document.getElementById("code_block_{id}");
-  if (x.style.display === "none") {
-    x.style.display = "block";
-  } else {
-    x.style.display = "none";
-  }
-}
-</script>
-"""
-
 class NotebookCell:
     def __init__(self, id, data):
         self.data = data
@@ -50,10 +28,6 @@ class NotebookCell:
             for line in self.data["source"]:
                 out_file.write(line)
         elif self.cell_type == "code":
-            # write code block with show-code button
-            formatted_code_block = CODE_BLOCK.replace("{id}", self.id).replace("{code}", "".join(self.data["source"]))
-            for line in formatted_code_block:
-                out_file.write(line)
             # write outputs
             for i, output_holder in enumerate(self.data["outputs"]):
               output = output_holder["data"]["text/html"]

--- a/post_from_notebook.py
+++ b/post_from_notebook.py
@@ -4,12 +4,6 @@ from argparse import ArgumentParser
 from typing import IO
 import yaml
 
-HEADER = """
-<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-<script src="https://requirejs.org/docs/release/2.3.5/minified/require.js"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-"""
-
 SCRIPT_TEMPLATE = """
 <div>
   <script>
@@ -87,7 +81,6 @@ class NotebookPost:
             for line in self.metadata:
               f.write(line)
             f.write("\n---\n")
-            f.write(HEADER)
             for cell in self.cells:
                 cell.render(f, asset_folder)
 


### PR DESCRIPTION
plotly js is now taken care of in head.html via `useplotly=true` in the front matter. See #246, #253, https://github.com/UBICenter/analysis-template/issues/19, and https://github.com/UBICenter/analysis-template/pull/20.

Instead of cluttering posts with code blocks, we're now linking to the source repo.