### PR TITLE
Update jekyll-deploy-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
             ${{ runner.os }}-gems-
 
       # Use GitHub Deploy Action to build and deploy to Github
-      - uses: jeffreytse/jekyll-deploy-action@v0.2.0
+      - uses: jeffreytse/jekyll-deploy-action@v0.2.1
         with:
           provider: 'github'
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Currently breaking, e.g. see https://github.com/UBICenter/ubicenter.org/runs/3355372833?check_suite_focus=true#step:2:4049

0.2.1 came out in January https://github.com/jeffreytse/jekyll-deploy-action/releases/tag/v0.2.1